### PR TITLE
Use graphics capture item picker

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ VRCHapticsLite
 **接触情報を画面上に映し出すアバター用 Prefab はこのリポジトリに含まれていません。**
 
 ## 動作環境
-- Windows 10 Version 1903 以上
+- Windows 10 Version 1803 以上
 - .NET Framework 4.7.2 以上
 
 ## 使用方法

--- a/VRCHapticsLite/MainViewModel.cs
+++ b/VRCHapticsLite/MainViewModel.cs
@@ -1,7 +1,10 @@
-﻿namespace VRCHapticsLite
+﻿using Reactive.Bindings;
+
+namespace VRCHapticsLite
 {
     class MainViewModel
     {
+        public ReactiveProperty<string> TargetName { get; } = new ReactiveProperty<string>(string.Empty);
         public ModuleConfigViewModel Head { get; } = new ModuleConfigViewModel();
         public ModuleConfigViewModel Vest { get; } = new ModuleConfigViewModel();
         public ModuleConfigViewModel LeftArm { get; } = new ModuleConfigViewModel();

--- a/VRCHapticsLite/MainWindow.xaml
+++ b/VRCHapticsLite/MainWindow.xaml
@@ -20,24 +20,20 @@
 
         <Grid>
             <Grid.ColumnDefinitions>
-                <ColumnDefinition Width="*"/>
-                <ColumnDefinition Width="5"/>
                 <ColumnDefinition Width="Auto"/>
+                <ColumnDefinition Width="5"/>
+                <ColumnDefinition Width="*"/>
             </Grid.ColumnDefinitions>
 
-            <ComboBox x:Name="WindowComboBox" Grid.Column="0" SelectionChanged="WindowComboBox_SelectionChanged">
-                <ComboBox.ItemTemplate>
-                    <DataTemplate>
-                        <TextBlock Text="{Binding MainWindowTitle}"/>
-                    </DataTemplate>
-                </ComboBox.ItemTemplate>
-            </ComboBox>
-            <Button x:Name="WindowListRefreshButton"
-                    Grid.Column="2"
-                    Padding="7,0,7,0"
-                    Click="WindowListRefreshButton_Click">
-                Refresh
+            <Button x:Name="SelectWindowButton"
+                    Grid.Column="0"
+                    Padding="7,3,7,3"
+                    Click="SelectWindowButton_Click">
+                Select Window
             </Button>
+            <TextBlock Grid.Column="2"
+                       VerticalAlignment="Center"
+                       Text="{Binding TargetName.Value, Mode=OneWay}"/>
         </Grid>
 
         <Grid Grid.Row="2">

--- a/VRCHapticsLite/Properties/AssemblyInfo.cs
+++ b/VRCHapticsLite/Properties/AssemblyInfo.cs
@@ -51,5 +51,5 @@ using System.Windows;
 // すべての値を指定するか、次を使用してビルド番号とリビジョン番号を既定に設定できます
 // 既定値にすることができます:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("0.1.1.0")]
-[assembly: AssemblyFileVersion("0.1.1.0")]
+[assembly: AssemblyVersion("0.1.1.1")]
+[assembly: AssemblyFileVersion("0.1.1.1")]

--- a/VRCHapticsLite/VRCHapticsLite.csproj
+++ b/VRCHapticsLite/VRCHapticsLite.csproj
@@ -180,7 +180,7 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.Windows.SDK.Contracts">
-      <Version>10.0.17763.1000-preview</Version>
+      <Version>10.0.17134.1000-preview</Version>
     </PackageReference>
     <PackageReference Include="ReactiveProperty">
       <Version>6.0.3</Version>


### PR DESCRIPTION
ターゲットウィンドウ選択に使用していた `IGraphicsCaptureItemInterop` が Windows 10 Version 1903 以降のみサポートとなっていたため、対象バージョンを広げるために `Windows.Graphics.Capture.GraphicsCapturePicker` に置き換えます。

参考: https://github.com/microsoft/Windows.UI.Composition-Win32-Samples/tree/master/dotnet/WPF/ScreenCapture
> This sample uses new APIs available in Windows 10 version 1903, SDK 18362:
> - `CreateForWindow` (HWND) and `CreateForMonitor` (HMON) APIs are in the Windows.Graphics.Capture.Interop.h header.